### PR TITLE
Fix additional slash issue when deploying with --config

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -1,4 +1,5 @@
 var shell = require('shelljs');
+var url = require('url');
 var util = require('util');
 
 function getCurrentBranch() {
@@ -30,7 +31,9 @@ function doGitPush(gitURL, branch, callback) {
 }
 
 function performGitDeployment(baseUrl, config, branch, callback) {
-  var deployURL = baseUrl + '/' + config;
+  baseUrl = url.parse(baseUrl);
+  baseUrl.pathname = config;
+  var deployURL = url.format(baseUrl);
 
   if (!isValidBranch(branch)) {
     console.error('Branch `%s` is not available in this repository', branch);


### PR DESCRIPTION
Hello, guys. I created config file for Process Manager and it looks like:

``` ini
[myapp]
prepare[] = npm rebuild

[myapp.files]
dst1 = src1
dst2 = src2
```

When I do `slc deploy --config myapp http://IP:PORT/ deploy` (as described [here](http://docs.strongloop.com/display/SLC/Process+Manager+config+file#ProcessManagerconfigfile-Deployinganamedconfiguration)), files are not copied and same thing with `prepare` steps.

I added some debug lines to `strong-pm` at [lib/config.js](https://github.com/strongloop/strong-pm/blob/253a56f41f2398bea058329c75f660a64aeba836/lib/config.js#L39) and found that `commit.repo` equals to `/myapp` and not `myapp`. I was wondering why it happens, then looked at [lib/git.js](https://github.com/strongloop/strong-deploy/blob/50e2fbf116b6b9e12eb932daf6bd3421be293025/lib/git.js#L33). So the problem is in ending slash symbol. It gets doubled if you specify deployment URL with it.

So I made a simple fix to ensure URL is correct.

Or if no need in this, could you correct StrongLoop documentation, please?
