### PR TITLE
Better errors when deploy failure is auth related

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ Options:
   -c,--config CFG    Deploy a specified configuration (default is "default").
 
 Arguments:
-  URL       The URL of the StrongLoop process manager
-            eg: http://127.0.0.1:7777
+  URL       The URL of the StrongLoop process manager, eg: http://127.0.0.1:7777
+            If the server requires authentication, the credentials must be part
+            of the URL, eg: http://user:pass@127.0.0.1:7777
   PACK      Deploy an NPM package/tarball.
   BRANCH    Deploy a git branch.
 

--- a/bin/sl-deploy.txt
+++ b/bin/sl-deploy.txt
@@ -8,8 +8,9 @@ Options:
   -c,--config CFG    Deploy a specified configuration (default is "default").
 
 Arguments:
-  URL       The URL of the StrongLoop process manager
-            eg: http://127.0.0.1:7777
+  URL       The URL of the StrongLoop process manager, eg: http://127.0.0.1:7777
+            If the server requires authentication, the credentials must be part
+            of the URL, eg: http://user:pass@127.0.0.1:7777
   PACK      Deploy an NPM package/tarball.
   BRANCH    Deploy a git branch.
 

--- a/lib/git.js
+++ b/lib/git.js
@@ -3,6 +3,8 @@ var childProcess = require('child_process');
 var debug = require('debug')('strong-deploy:git');
 var shell = require('shelljs');
 var util = require('util');
+var urlParse = require('url').parse;
+var urlFormat = require('url').format;
 
 function getCurrentBranch(workingDir) {
   if (!shell.pushd(workingDir)) {
@@ -42,7 +44,12 @@ function isValidGitURL(workingDir, url, callback) {
     debug('stderr: ' + stderr);
     if (err) {
       debug(err);
-      console.error('URL `%s` is not valid', url);
+      if (urlFormat(urlParse(url)) == url) {
+        console.error('Cannot access remote. Does git require authentication?');
+        console.error('If authentication is required, credentials should be given in the URL.');
+      } else {
+        console.error('URL `%s` is not valid', url);
+      }
       err = Error('invalid url');
     }
     callback(err);

--- a/lib/put-file.js
+++ b/lib/put-file.js
@@ -37,6 +37,9 @@ function performHttpPutDeployment(baseURL, config, npmPkg, callback) {
       baseURL,
       res.statusCode
     );
+    if (res.statusCode === 401 || res.statusCode === 403) {
+      console.error('Valid credentials must be given in the URL');
+    }
     callback(Error('HTTP error'));
   });
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "async": "^0.9.0",
+    "http-auth": "^2.2.5",
     "strong-fork-cicada": "^1.1.2",
     "tap": "^0.4.9"
   }

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
     "posix-getopt": "^1.0.0"
   },
   "devDependencies": {
-    "tap": "^0.4.9",
-    "cicada": "^1.1.1",
-    "async": "^0.9.0"
+    "async": "^0.9.0",
+    "strong-fork-cicada": "^1.1.2",
+    "tap": "^0.4.9"
   }
 }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,43 @@
+var assert = require('assert');
+var cicada = require('strong-fork-cicada');
+var debug = require('debug')('test');
+var http = require('http');
+var path = require('path');
+var shell = require('shelljs');
+
+var artifactDir = path.join(__dirname, '.test_artifacts');
+
+shell.rm('-rf', artifactDir);
+
+var ci = cicada(artifactDir);
+
+module.exports = exports = {
+  gitServer:       httpServer.bind(null, [ci.handle]),
+  httpServer:      httpServer.bind(null, []),
+  ok:              false,
+};
+
+// Check for node silently exiting with code 0 when tests have not passed.
+process.on('exit', function(code) {
+  if (code === 0) {
+    assert(exports.ok);
+  }
+});
+
+function httpServer(handlers, customHandler, callback) {
+  if (customHandler) {
+    if (callback) {
+      handlers.push(customHandler);
+    } else {
+      callback = customHandler;
+    }
+  }
+  var server = http.createServer.apply(http, handlers);
+
+  return server.listen(0, returnServer);
+
+  function returnServer() {
+    debug('Server started at: %j', server.address());
+    callback(server, ci);
+  }
+}

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -21,6 +21,7 @@ module.exports = exports = {
   httpServerAllow: httpServer.bind(null, [allowAll]),
   httpServerDeny:  httpServer.bind(null, [denyAll]),
   httpServer:      httpServer.bind(null, []),
+  assertMatch:     assertMatch,
   ok:              false,
 };
 
@@ -53,5 +54,13 @@ function alwaysSay(result) {
   return function(user, pass, callback) {
     debug('HTTP Auth: %s:%s => %s', user, pass, result ? 'ALLOW' : 'DENY');
     callback(result);
+  }
+}
+
+function assertMatch(actual, expected, message) {
+  actual = actual.toString('utf8');
+  expected = new RegExp(expected);
+  if (!expected.test(actual)) {
+    assert.fail(actual, expected.toString(), message, 'match');
   }
 }

--- a/test/test-deploy-default-branch.js
+++ b/test/test-deploy-default-branch.js
@@ -1,31 +1,24 @@
 var assert = require('assert');
 var childProcess = require('child_process');
-var cicada = require('cicada');
-var debug = require('debug')('test');
-var http = require('http');
+var helpers = require('./helpers');
 var shell = require('shelljs');
 
 shell.exec('git branch deploy');
-shell.rm('-rf', '.test_artifacts');
-var ci = cicada('.test_artifacts');
-var server = http.createServer(ci.handle);
-var ok = false;
+helpers.gitServer(test);
 
-ci.once('commit', function(commit) {
-  assert(commit.repo === 'default');
-  var branch = 'deploy';
-  assert(!(branch instanceof Error));
-  assert(commit.branch === branch);
-  ok = true;
-  server.close();
-});
+function test(server, ci) {
+  ci.once('commit', assertCommit);
 
-server.once('listening', function() {
-  debug('Server started at: %j', server.address());
   childProcess.fork(
     require.resolve('../bin/sl-deploy'),
-    ['http://127.0.0.1:' + server.address().port]
+    ['http://any:thin@127.0.0.1:' + server.address().port]
   );
-});
 
-server.listen(0);
+  function assertCommit(commit) {
+    assert(commit.repo === 'default');
+    var branch = 'deploy';
+    assert(commit.branch === branch);
+    helpers.ok = true;
+    server.close();
+  }
+}

--- a/test/test-deploy-specific-branch.js
+++ b/test/test-deploy-specific-branch.js
@@ -1,15 +1,9 @@
 var assert = require('assert');
 var childProcess = require('child_process');
-var cicada = require('cicada');
-var debug = require('debug')('test');
-var http = require('http');
 var shell = require('shelljs');
-var getCurrentBranch = require('../lib/git.js')._getCurrentBranch;
+var helpers = require('./helpers');
 
-shell.rm('-rf', '.test_artifacts');
-var ci = cicada('.test_artifacts');
-var server = http.createServer(ci.handle);
-var ok = false;
+var getCurrentBranch = require('../lib/git.js')._getCurrentBranch;
 var currentBranch = getCurrentBranch(process.cwd());
 
 // Ensure that master and production exist as local branches
@@ -23,19 +17,17 @@ if (currentBranch instanceof Error || currentBranch === 'production') {
   pushBranch = 'master';
 }
 
-ci.once('commit', function(commit) {
-  assert(commit.repo === 'repo2');
-  assert(commit.branch === pushBranch);
-  ok = true;
-  server.close();
-});
-
-server.once('listening', function() {
-  debug('Server started at: %j', server.address());
+helpers.gitServer(function(server, ci) {
+  ci.once('commit', assertCommit);
   childProcess.fork(
     require.resolve('../bin/sl-deploy'),
     ['--config', 'repo2', 'http://127.0.0.1:' + server.address().port, pushBranch]
   );
-});
 
-server.listen(0);
+  function assertCommit(commit) {
+    assert(commit.repo === 'repo2');
+    assert(commit.branch === pushBranch);
+    helpers.ok = true;
+    server.close();
+  }
+});

--- a/test/test-git-deploy-auth-failure.js
+++ b/test/test-git-deploy-auth-failure.js
@@ -1,0 +1,30 @@
+var assert = require('assert');
+var childProcess = require('child_process');
+var debug = require('debug')('test');
+var helpers = require('./helpers');
+
+helpers.gitServerDeny(test);
+
+function test(server, ci) {
+  ci.once('commit', assertNoCommit);
+  var deploy = childProcess.fork(
+    require.resolve('../bin/sl-deploy'),
+    ['http://any:thing@127.0.0.1:' + server.address().port],
+    { env: { GIT_ASKPASS: 'echo' }, silent: true }
+  );
+  deploy.on('exit', function(code, signal) {
+    helpers.ok = true;
+    server.close();
+    var stderr = deploy.stderr.read();
+    var stdout = deploy.stdout.read();
+    debug('sl-deploy stdout: %s', stdout);
+    debug('sl-deploy stderr: %s', stderr);
+    assert.notEqual(code, 0, 'sl-deploy should exit with failure');
+    helpers.assertMatch(stderr, /If authentication is required/i);
+    helpers.assertMatch(stderr, /credentials should be given in the URL/i);
+  });
+}
+
+function assertNoCommit(commit) {
+  assert.fail('commit', 'none', 'cicada should never see this');
+}

--- a/test/test-git-deploy-auth.js
+++ b/test/test-git-deploy-auth.js
@@ -1,0 +1,24 @@
+var assert = require('assert');
+var childProcess = require('child_process');
+var helpers = require('./helpers');
+var shell = require('shelljs');
+
+shell.exec('git branch deploy');
+helpers.gitServerAllow(test);
+
+function test(server, ci) {
+  ci.once('commit', assertCommit);
+
+  childProcess.fork(
+    require.resolve('../bin/sl-deploy'),
+    ['http://any:thin@127.0.0.1:' + server.address().port]
+  );
+
+  function assertCommit(commit) {
+    assert(commit.repo === 'default');
+    var branch = 'deploy';
+    assert(commit.branch === branch);
+    helpers.ok = true;
+    server.close();
+  }
+}

--- a/test/test-put-deploy-auth-failure.js
+++ b/test/test-put-deploy-auth-failure.js
@@ -1,0 +1,30 @@
+var assert = require('assert');
+var childProcess = require('child_process');
+var debug = require('debug')('test');
+var helpers = require('./helpers');
+
+var server = helpers.httpServerDeny(assertNoPut, doPut);
+
+function assertNoPut(req, res) {
+  assert.fail('request', 'none', 'Handler should never see request');
+}
+
+function doPut(server, _ci) {
+  var port = server.address().port;
+  var put = childProcess.fork(
+    require.resolve('../bin/sl-deploy'),
+    ['--config', 'repo2', 'http://always:allow@127.0.0.1:' + port, __filename],
+    { silent: true }
+  );
+  put.on('exit', function(code, signal) {
+    helpers.ok = true;
+    server.close();
+    var stderr = put.stderr.read();
+    var stdout = put.stdout.read();
+    debug('sl-deploy stdout: %s', stdout);
+    debug('sl-deploy stderr: %s', stderr);
+    assert.notEqual(code, 0, 'sl-deploy should exit with failure');
+    helpers.assertMatch(stderr, /HTTP Code: 401/i);
+    helpers.assertMatch(stderr, /credentials must be given in the URL/i);
+  });
+}

--- a/test/test-put-deploy-auth.js
+++ b/test/test-put-deploy-auth.js
@@ -1,0 +1,22 @@
+var assert = require('assert');
+var childProcess = require('child_process');
+var helpers = require('./helpers');
+
+var server = helpers.httpServerAllow(assertPut, doPut);
+
+function assertPut(req, res) {
+  assert(req.url === '/repo2');
+  assert(req.method === 'PUT');
+  helpers.ok = true;
+
+  res.end();
+  server.close();
+}
+
+function doPut(server, _ci) {
+  var port = server.address().port;
+  childProcess.fork(
+    require.resolve('../bin/sl-deploy'),
+    ['--config', 'repo2', 'http://always:allow@127.0.0.1:' + port, __filename]
+  );
+}

--- a/test/test-put-file-deploy.js
+++ b/test/test-put-file-deploy.js
@@ -1,22 +1,22 @@
 var assert = require('assert');
-var http = require('http');
 var childProcess = require('child_process');
+var helpers = require('./helpers');
 
-var ok = false;
-var server = http.createServer(function(req, res) {
+var server = helpers.httpServer(assertPut, doPut);
+
+function assertPut(req, res) {
   assert(req.url === '/repo2');
   assert(req.method === 'PUT');
-  ok = true;
+  helpers.ok = true;
 
   res.end();
   server.close();
-});
-server.listen(0);
+}
 
-server.on('listening', function() {
+function doPut(server, _ci) {
   var port = server.address().port;
   childProcess.fork(
     require.resolve('../bin/sl-deploy'),
     ['--config', 'repo2', 'http://127.0.0.1:' + port, __filename]
   );
-});
+}

--- a/test/test-usage.js
+++ b/test/test-usage.js
@@ -3,6 +3,7 @@ var async = require('async');
 var debug = require('debug')('strong-deploy:test');
 var path = require('path');
 var util = require('util');
+var helpers = require('./helpers');
 
 require('shelljs/global');
 
@@ -18,15 +19,6 @@ function deployCli(args, cb) {
   }
   return cb();
 }
-
-// Check for node silently exiting with code 0 when tests have not passed.
-var ok = false;
-
-process.on('exit', function(code) {
-  if (code === 0) {
-    assert(ok);
-  }
-});
 
 function expectError(er) {
   if (er) {
@@ -63,5 +55,5 @@ async.parallel([
 ], function(er, results) {
   debug('test-help: error=%s:', er, results);
   assert.ifError(er);
-  ok = true;
+  helpers.ok = true;
 });


### PR DESCRIPTION
 * Add description of how to specify credentials in URL
 * Mention auth in error message if missing/bad credentials is the cause
 * Add regression tests to ensure the previously implicit auth support doesn't break

Connected to #21 