### PR TITLE
local deploy: tune messaging on failure

### DIFF
--- a/bin/sl-deploy.js
+++ b/bin/sl-deploy.js
@@ -3,6 +3,7 @@
 'use strict';
 
 var Parser = require('posix-getopt').BasicParser;
+var debug = require('debug')('strong-deploy');
 var defaults = require('strong-url-defaults');
 var deploy = require('../');
 var fs = require('fs');
@@ -61,9 +62,8 @@ if (numArgs > 2) {
 }
 
 var baseURL = argv[parser.optind()];
-if (numArgs === 2) {
-  branchOrPack = argv[parser.optind() + 1];
-}
+branchOrPack = argv[parser.optind() + 1];
+
 baseURL = baseURL || 'http://';
 branchOrPack = branchOrPack || 'deploy';
 
@@ -71,6 +71,8 @@ branchOrPack = branchOrPack || 'deploy';
 // concatenation of '/<config>', and older versions of deploy allowed paths on
 // the git push.
 baseURL = defaults(baseURL, {host: '127.0.0.1', port: 8701}, {path: '/'});
+
+debug('deploy %j to %j', branchOrPack, baseURL);
 
 if (!local)
   deploy(process.cwd(), baseURL, branchOrPack, config, exit);

--- a/lib/post-json.js
+++ b/lib/post-json.js
@@ -1,3 +1,5 @@
+var concat = require('concat-stream');
+var debug = require('debug')('strong-deploy');
 var http = require('http');
 var path = require('path');
 var shell = require('shelljs');
@@ -23,7 +25,7 @@ function performLocalDeployment(baseURL, what, config, callback) {
   }
 
   if (!shell.test('-d', what)) {
-    console.error('Invalid path `%s`. Only directories are supported.', what);
+    console.error('Cannot deploy `%s`: not an npm package directory', what);
     return callback(Error('Invalid path, not a directory'));
   }
 
@@ -37,28 +39,24 @@ function performLocalDeployment(baseURL, what, config, callback) {
       'Content-Type': 'application/x-pm-deploy',
     },
   };
+  var postBody = {
+    'local-directory': what,
+  };
+
+  debug('post %j options %j', postBody, postOptions);
 
   var req = http.request(postOptions, function(res) {
-    res.on('data', function() {
-      // discard
-    });
-    res.on('end', function() {
+    res.pipe(concat(res, function(msg) {
+      debug('response: code=%d %j', res.statusCode, String(msg));
       if (res.statusCode === 200) {
         return callback();
       }
-      console.error(
-        'Deploy `%s` to `%s` failed. HTTP Code: %d',
-        what,
-        baseURL,
-        res.statusCode
-      );
+      console.error('%s', msg);
       callback(Error('HTTP error ' + res.statusCode));
-    });
+    }));
   });
 
-  req.end(JSON.stringify({
-    'local-directory': what,
-  }));
+  req.end(JSON.stringify(postBody));
 
   req.on('error', function(err) {
     console.error('Deploy `%s` to `%s` failed: %s',

--- a/package.json
+++ b/package.json
@@ -35,9 +35,10 @@
   },
   "dependencies": {
     "async": "^0.9.0",
+    "concat-stream": "^1.4.7",
     "debug": "^2.0.0",
-    "shelljs": "^0.3.0",
     "posix-getopt": "^1.0.0",
+    "shelljs": "^0.3.0",
     "strong-url-defaults": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Tested with some failed deploys, and added the server response message
(not just the HTTP code) into the failure output, also added some debug
output.