### PR TITLE
Improve git error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ prepared using [strong-build](http://github.com/strongloop/strong-build).
 ## Usage
 
 ```
-usage: sl-deploy.js [options] [URL [PACK|BRANCH]]
+usage: sl-deploy [options] [URL [PACK|BRANCH]]
 
 Deploy a node application to a StrongLoop process manager
 
@@ -38,15 +38,19 @@ Note that if PACK or BRANCH is specified, URL *must* be specified as well.
 
 Examples:
 
-Deploy to localhost:
+Deploy 'deploy' branch to localhost:
 
-    sl-deploy.js deploy
+    sl-deploy
 
-Deploy to a remote host:
+Deploy 'deploy' branch to a remote host:
 
-    sl-deploy.js deploy http://prod1.example.com
+    sl-deploy http://prod1.example.com
 
 Deploy to a remote host, on a non-standard port, using authentication:
 
-    sl-deploy.js http://user:pass@prod1.example.com:8765
+    sl-deploy http://user:pass@prod1.example.com:8765
+
+Deploy 'production' branch to localhost:
+
+    sl-deploy http://localhost production
 ```

--- a/bin/sl-deploy.txt
+++ b/bin/sl-deploy.txt
@@ -26,14 +26,18 @@ Note that if PACK or BRANCH is specified, URL *must* be specified as well.
 
 Examples:
 
-Deploy to localhost:
+Deploy 'deploy' branch to localhost:
 
-    %MAIN% deploy
+    %MAIN%
 
-Deploy to a remote host:
+Deploy 'deploy' branch to a remote host:
 
-    %MAIN% deploy http://prod1.example.com
+    %MAIN% http://prod1.example.com
 
 Deploy to a remote host, on a non-standard port, using authentication:
 
     %MAIN% http://user:pass@prod1.example.com:8765
+
+Deploy 'production' branch to localhost:
+
+    %MAIN% http://localhost production

--- a/lib/git.js
+++ b/lib/git.js
@@ -48,6 +48,7 @@ function isValidGitURL(workingDir, url, callback) {
       debug(err);
       if (urlFormat(urlParse(url)) === url) {
         console.error(msg);
+        console.error('git: %s', stderr);
       } else {
         console.error('URL `%s` is not valid', url);
       }


### PR DESCRIPTION
Original:
```
$ sl-deploy http://:8777    
Cannot access remote. Does git require authentication?
If authentication is required, credentials should be given in the URL.
```
New:
```
$ sl-deploy http://:8777
Cannot access remote. Does git require authentication?
If authentication is required, credentials should be given in the URL.
git: fatal: unable to access 'http://127.0.0.1:8777/default/': Failed to connect to 127.0.0.1 port 8777: Connection refused
```

I also updated the usage text to clarify the examples.

Connects to #27 