### PR TITLE
Add support for deploying using http over ssh

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ Arguments:
     If the server requires authentication, the credentials must be part of the
     URL, see examples.
 
+    URL may also use the `http+ssh://` protocol which will connect using ssh
+    and then tunnel the http requests over that connection. The ssh username
+    will default to your current user and authentication defaults to using your
+    current ssh-agent. The username can be overridden by setting an `SSH_USER`
+    environment variable. The authentication can be overridden to use an
+    existing private key instead of an agent by setting the `SSH_KEY`
+    environment variable to the path of the private key to be used.
+
   PACK: Deploy an NPM package/tarball.
 
   BRANCH: Deploy a git branch.

--- a/bin/sl-deploy.txt
+++ b/bin/sl-deploy.txt
@@ -15,6 +15,14 @@ Arguments:
     If the server requires authentication, the credentials must be part of the
     URL, see examples.
 
+    URL may also use the `http+ssh://` protocol which will connect using ssh
+    and then tunnel the http requests over that connection. The ssh username
+    will default to your current user and authentication defaults to using your
+    current ssh-agent. The username can be overridden by setting an `SSH_USER`
+    environment variable. The authentication can be overridden to use an
+    existing private key instead of an agent by setting the `SSH_KEY`
+    environment variable to the path of the private key to be used.
+
   PACK: Deploy an NPM package/tarball.
 
   BRANCH: Deploy a git branch.

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "debug": "^2.0.0",
     "posix-getopt": "^1.0.0",
     "shelljs": "^0.3.0",
+    "strong-tunnel": "^1.1.7",
     "strong-url-defaults": "^1.0.0"
   },
   "devDependencies": {

--- a/test/test-git-http-ssh.js
+++ b/test/test-git-http-ssh.js
@@ -1,0 +1,24 @@
+var assert = require('assert');
+var childProcess = require('child_process');
+var helpers = require('./helpers');
+var shell = require('shelljs');
+
+shell.exec('git branch deploy');
+helpers.gitServer(test);
+
+function test(server, ci) {
+  ci.once('commit', assertCommit);
+
+  childProcess.fork(
+    require.resolve('../bin/sl-deploy'),
+    ['http+ssh://127.0.0.1:' + server.address().port]
+  );
+
+  function assertCommit(commit) {
+    assert(commit.repo === 'default');
+    var branch = 'deploy';
+    assert(commit.branch === branch);
+    helpers.ok = true;
+    server.close();
+  }
+}

--- a/test/test-put-file-http-ssh.js
+++ b/test/test-put-file-http-ssh.js
@@ -1,0 +1,21 @@
+var assert = require('assert');
+var childProcess = require('child_process');
+var helpers = require('./helpers');
+
+var server = helpers.httpServer(assertPut, doPut);
+
+function assertPut(req, res) {
+  assert(req.method === 'PUT');
+  helpers.ok = true;
+
+  res.end();
+  server.close();
+}
+
+function doPut(server, _ci) {
+  var port = server.address().port;
+  childProcess.fork(
+    require.resolve('../bin/sl-deploy'),
+    ['http+ssh://127.0.0.1:' + port, __filename]
+  );
+}


### PR DESCRIPTION
Modelled after the support in strong-pm

* [x] support `sl-deploy http+ssh://localhost:8701/default`
* [x] tests for http+ssh://
* [x] docs/usage update describing http+ssh://

Connects to #29 

/cc @chandadharap 