### PR TITLE
Support multiapp pm in deploy APIs

### DIFF
--- a/bin/sl-deploy.js
+++ b/bin/sl-deploy.js
@@ -67,6 +67,9 @@ if (numArgs > 2) {
 
 var workingDir = process.cwd();
 
+// XXX(sam) our CWD isn't necessarily the package we are deploying, we should
+// get the package name from the git branch, or the tarball being deployed,
+// or the path being deployed.
 var packageInfo = getPackageInfo(workingDir);
 serviceName = serviceName || (packageInfo ? packageInfo.name : null);
 
@@ -109,27 +112,16 @@ if (!local)
       return exit(err);
     }
     debug('Connecting to %s via %s', baseURL, url);
-    var client = new MeshClient(url);
-    client.serviceFindOrCreate(serviceName, 1, function(err, service) {
-      if (err) {
-        if (err.statusCode === 401) {
-          console.error(
-            'Cannot access remote. If authentication is required,' +
-            ' credentials should be given in the URL.');
-        } else {
-          console.error('Error connecting to server:', err);
-        }
-        return exit(err);
-      }
-      deploy(
-        workingDir, service.getDeployEndpoint(),
-        branchOrPack,
-        exit
-      );
-    });
+    deploy(
+      workingDir,
+      url,
+      serviceName,
+      branchOrPack,
+      exit
+    );
   });
 else
-  deploy.local(baseURL, branchOrPack, exit);
+  deploy.local(baseURL, serviceName, branchOrPack, exit);
 
 function exit(err) {
   if (!err) {

--- a/index.js
+++ b/index.js
@@ -18,10 +18,10 @@ module.exports.local = localDeployment;
  * @param {string} branchOrPack Name of the GIT branch or path to the NPM pack.
  * @param {function} cb Callback
  */
-function deploy(workingDir, baseURL, branchOrPack, cb) {
+function deploy(workingDir, baseURL, serviceName, branchOrPack, cb) {
   if (shell.test('-f', path.resolve(branchOrPack))) {
-    return httpPutDeployment(baseURL, branchOrPack, cb);
+    return httpPutDeployment(baseURL, serviceName, branchOrPack, cb);
   } else {
-    return gitDeployment(workingDir, baseURL, branchOrPack, cb);
+    return gitDeployment(workingDir, baseURL, serviceName, branchOrPack, cb);
   }
 }

--- a/lib/deploy-endpoint.js
+++ b/lib/deploy-endpoint.js
@@ -1,0 +1,22 @@
+'use strict';
+
+var MeshClient = require('strong-mesh-models').Client;
+
+exports.get = getDeployEndpoint;
+
+function getDeployEndpoint(url, serviceName, callback) {
+  var client = new MeshClient(url);
+  client.serviceFindOrCreate(serviceName, 1, function(err, service) {
+    if (err) {
+      if (err.statusCode === 401) {
+        console.error(
+          'Cannot access remote. If authentication is required,' +
+          ' credentials should be given in the URL.');
+      } else {
+        console.error('Error connecting to server:', err);
+      }
+      return callback(err);
+    }
+    return callback(null, service.getDeployEndpoint());
+  });
+}

--- a/lib/git.js
+++ b/lib/git.js
@@ -1,6 +1,7 @@
 var async = require('async');
 var childProcess = require('child_process');
 var debug = require('debug')('strong-deploy:git');
+var getDeployEndpoint = require('./deploy-endpoint').get;
 var shell = require('shelljs');
 var util = require('util');
 var urlParse = require('url').parse;
@@ -78,7 +79,14 @@ function doGitPush(workingDir, gitURL, branch, callback) {
   });
 }
 
-function performGitDeployment(workingDir, baseUrl, branch, callback) {
+function performGitDeployment(workingDir, baseUrl, svcName, branch, callback) {
+  getDeployEndpoint(baseUrl, svcName, function(err, deployUrl) {
+    if (err) return callback(err);
+    _performGitDeployment(workingDir, deployUrl, branch, callback);
+  });
+}
+
+function _performGitDeployment(workingDir, baseUrl, branch, callback) {
   var deployURL = baseUrl + '/default';
   async.series([
     isValidBranch.bind(null, workingDir, branch),

--- a/lib/post-json.js
+++ b/lib/post-json.js
@@ -1,11 +1,21 @@
 var concat = require('concat-stream');
 var debug = require('debug')('strong-deploy');
+var getDeployEndpoint = require('./deploy-endpoint').get;
 var http = require('http');
 var path = require('path');
 var shell = require('shelljs');
 var url = require('url');
 
-function performLocalDeployment(baseURL, what, config, callback) {
+exports.performLocalDeployment = performLocalDeployment;
+
+function performLocalDeployment(baseURL, serviceName, what, callback) {
+  getDeployEndpoint(baseURL, serviceName, function(err, deployUrl) {
+    if (err) return callback(err);
+      _performLocalDeployment(deployUrl, what, callback);
+  });
+}
+
+function _performLocalDeployment(baseURL, what, callback) {
   what = path.resolve(what);
 
   var postURL = url.parse(baseURL);
@@ -33,7 +43,7 @@ function performLocalDeployment(baseURL, what, config, callback) {
     auth: postURL.auth,
     hostname: 'localhost',
     port: postURL.port || 80,
-    path: '/' + config,
+    path: postURL.path + '/default',
     method: 'POST',
     headers: {
       'Content-Type': 'application/x-pm-deploy',
@@ -67,5 +77,3 @@ function performLocalDeployment(baseURL, what, config, callback) {
     callback(err);
   });
 }
-
-exports.performLocalDeployment = performLocalDeployment;

--- a/lib/put-file.js
+++ b/lib/put-file.js
@@ -1,11 +1,19 @@
 var concat = require('concat-stream');
 var debug = require('debug')('strong-deploy');
 var fs = require('fs');
+var getDeployEndpoint = require('./deploy-endpoint').get;
 var http = require('http');
 var path = require('path');
 var url = require('url');
 
-function performHttpPutDeployment(baseURL, npmPkg, callback) {
+function performHttpPutDeployment(baseURL, serviceName, npmPkg, callback) {
+  getDeployEndpoint(baseURL, serviceName, function(err, deployUrl) {
+    if (err) return callback(err);
+    _performHttpPutDeployment(deployUrl, npmPkg, callback);
+  });
+}
+
+function _performHttpPutDeployment(baseURL, npmPkg, callback) {
   npmPkg = path.resolve(npmPkg);
 
   var fileReader = fs.createReadStream(npmPkg);

--- a/test/test-deploy-from-workingdir.js
+++ b/test/test-deploy-from-workingdir.js
@@ -18,7 +18,7 @@ function test(server, ci) {
   process.chdir(os.tmpdir());
 
   debug('workingDir: %s', workingDir);
-  performGitDeployment(workingDir, baseUrl, 'deploy', function(err) {
+  performGitDeployment(workingDir, baseUrl, 'svc', 'deploy', function(err) {
     assert.ifError(err);
   });
 


### PR DESCRIPTION
sl-deploy was resolving a service name to the deploy URL, but this is
commonly needed code: the deploy APIs can't be used if you don't know
the URl to deploy to, and its the mesh client that can tell us. Refactor
so the APIs do the resolution.

In the process, fix local deploy, which didn't get multiapp support when
it was added for packfile and git deployments.

connected to strongloop/strong-start#8