### PR TITLE
use provided service name in error as fallback

### DIFF
--- a/bin/sl-deploy.js
+++ b/bin/sl-deploy.js
@@ -126,7 +126,7 @@ else
   deploy.local(baseURL, serviceName, branchOrPack, exit);
 
 function exit(err, service) {
-  var svc = service ? (service.name || service.id) : 'unknown';
+  var svc = service ? (service.name || service.id) : serviceName;
   if (err) {
     console.error('Failed to deploy `%s` as `%s` to `%s` via `%s`',
                   branchOrPack, svc, baseURL, exit.url);


### PR DESCRIPTION
This is less informative in that it hides whether the name could be
resolved or not, but it is far less surprising to the user.

Connect to strongloop-internal/scrum-nodeops#517