### PR TITLE
sl-deploy API accept cluster size parameter

### DIFF
--- a/bin/sl-deploy.txt
+++ b/bin/sl-deploy.txt
@@ -6,8 +6,11 @@ Options:
   -h,--help          Print this message and exit.
   -v,--version       Print version and exit.
   -s,--service SVC   Deploy to service SVC.
+  -z,--size SIZE     Set size of cluster to SIZE before deploy.
 
 Arguments:
+  SIZE: A number, n, or the string 'cpus', meaning run a worker per CPU.
+
   SVC: The name or ID of the service on the process manager.
 
     Defaults to the name of the application specified in the package.json file.

--- a/index.js
+++ b/index.js
@@ -13,15 +13,17 @@ module.exports.local = localDeployment;
 /**
  * Deploy a NPM pack or GIT branch to a strong-pm service
  *
- * @param {string} workingDir The working directory
- * @param {string} baseURL The URL of the service.
+ * @param {string} options.workingDir The working directory
+ * @param {string} options.baseURL The URL of the service.
+ * @param {integer} options.serviceName The name of the service.
+ * @param {integer} options.clusterSize The size of the cluster.
  * @param {string} branchOrPack Name of the GIT branch or path to the NPM pack.
  * @param {function} cb Callback
  */
-function deploy(workingDir, baseURL, serviceName, branchOrPack, cb) {
-  if (shell.test('-f', path.resolve(branchOrPack))) {
-    return httpPutDeployment(baseURL, serviceName, branchOrPack, cb);
+function deploy(options, cb) {
+  if (shell.test('-f', path.resolve(options.branchOrPack))) {
+    return httpPutDeployment(options, cb);
   } else {
-    return gitDeployment(workingDir, baseURL, serviceName, branchOrPack, cb);
+    return gitDeployment(options, cb);
   }
 }

--- a/lib/deploy-endpoint.js
+++ b/lib/deploy-endpoint.js
@@ -5,7 +5,7 @@ var debug = require('debug')('strong-deploy');
 
 exports.get = getDeployEndpoint;
 
-function getDeployEndpoint(url, serviceName, callback) {
+function getDeployEndpoint(url, serviceName, clusterSize, callback) {
   var client = new MeshClient(url);
   client.checkRemoteApiSemver(function(err) {
     if (err) {
@@ -13,11 +13,11 @@ function getDeployEndpoint(url, serviceName, callback) {
                     url, err.message || err);
       return callback(err);
     }
-    serviceFindOrCreate(client, serviceName, callback);
+    serviceFindOrCreate(client, serviceName, clusterSize, callback);
   });
 }
 
-function serviceFindOrCreate(client, serviceName, callback) {
+function serviceFindOrCreate(client, serviceName, clusterSize, callback) {
   client.serviceFindOrCreate(serviceName, 1, function(err, service) {
     if (err) {
       debug('client.serviceFindOrCreate(%s, 1): %s', serviceName, err);
@@ -33,6 +33,14 @@ function serviceFindOrCreate(client, serviceName, callback) {
     var endpoint = service.getDeployEndpoint();
     debug('client.serviceFindOrCreate(%s, 1): endpoint %s svc %j',
           serviceName, endpoint, service);
-    return callback(null, endpoint, service);
+    if (clusterSize != null) service.setClusterSize(clusterSize, true,
+      function(err) {
+        debug('service.setClusterSize(%s): serviceName %s endpoint %s svc %j',
+          clusterSize, serviceName, endpoint, service);
+        if (err) callback(err);
+        return callback(null, endpoint, service);
+      });
+    else callback(null, endpoint, service);
   });
 }
+

--- a/lib/git.js
+++ b/lib/git.js
@@ -79,11 +79,13 @@ function doGitPush(workingDir, gitURL, branch, callback) {
   });
 }
 
-function performGitDeployment(workingDir, baseUrl, svcName, branch, callback) {
-  getDeployEndpoint(baseUrl, svcName, function(err, deployUrl, service) {
-    if (err) return callback(err);
-    _performGitDeployment(service, workingDir, deployUrl, branch, callback);
-  });
+function performGitDeployment(options, callback) {
+  getDeployEndpoint(options.baseURL, options.serviceName, options.clusterSize,
+    function(err, deployUrl, service) {
+      if (err) return callback(err);
+      _performGitDeployment(service, options.workingDir, deployUrl,
+          options.branchOrPack, callback);
+    });
 }
 
 function _performGitDeployment(service, workingDir, baseUrl, branch, callback) {

--- a/lib/post-json.js
+++ b/lib/post-json.js
@@ -8,11 +8,13 @@ var url = require('url');
 
 exports.performLocalDeployment = performLocalDeployment;
 
-function performLocalDeployment(baseURL, serviceName, what, callback) {
-  getDeployEndpoint(baseURL, serviceName, function(err, deployUrl, service) {
-    if (err) return callback(err);
-    _performLocalDeployment(service, deployUrl, what, callback);
-  });
+function performLocalDeployment(options, callback) {
+  getDeployEndpoint(options.baseURL, options.serviceName, options.clusterSize,
+    function(err, deployUrl, service) {
+      if (err) return callback(err);
+      _performLocalDeployment(service, deployUrl,
+          options.branchOrPack, callback);
+    });
 }
 
 function _performLocalDeployment(service, baseURL, what, callback) {

--- a/lib/put-file.js
+++ b/lib/put-file.js
@@ -6,11 +6,13 @@ var http = require('http');
 var path = require('path');
 var url = require('url');
 
-function performHttpPutDeployment(baseURL, serviceName, npmPkg, callback) {
-  getDeployEndpoint(baseURL, serviceName, function(err, deployUrl, service) {
-    if (err) return callback(err);
-    _performHttpPutDeployment(service, deployUrl, npmPkg, callback);
-  });
+function performHttpPutDeployment(options, callback) {
+  getDeployEndpoint(options.baseURL, options.serviceName, options.clusterSize,
+    function(err, deployUrl, service) {
+      if (err) return callback(err);
+      _performHttpPutDeployment(service, deployUrl,
+          options.branchOrPack, callback);
+    });
 }
 
 function _performHttpPutDeployment(service, baseURL, npmPkg, callback) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "strong-deploy",
   "description": "Deploy a node application to a StrongLoop process manager",
-  "version": "2.2.2",
+  "version": "3.0.0",
   "keywords": [
     "StrongLoop",
     "build",

--- a/test/test-deploy-from-workingdir.js
+++ b/test/test-deploy-from-workingdir.js
@@ -18,8 +18,15 @@ function test(server, ci) {
   process.chdir(os.tmpdir());
 
   debug('workingDir: %s', workingDir);
-  performGitDeployment(workingDir, baseUrl, 'svc', 'deploy', function(err) {
-    assert.ifError(err);
+  performGitDeployment(
+    {
+      workingDir: workingDir,
+      baseURL: baseUrl,
+      serviceName: 'svc',
+      branchOrPack: 'deploy',
+    },
+    function(err) {
+      assert.ifError(err);
   });
 
   function assertCommit(commit) {


### PR DESCRIPTION
sl-deploy CLI accepts -z (--size) option and set the service to the cluster size
sl-deploy API takes options object instead of many arguments
sl-deploy API accepts cluster size in the options

connect to strongloop/strong-arc#582