### PR TITLE
Add 'use strict' to files

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -3,6 +3,8 @@
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
 
+'use strict';
+
 var async = require('async');
 var childProcess = require('child_process');
 var debug = require('debug')('strong-deploy:git');

--- a/lib/package.js
+++ b/lib/package.js
@@ -3,6 +3,8 @@
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
 
+'use strict';
+
 var debug = require('debug')('strong-deploy:package');
 var fs = require('fs');
 var path = require('path');

--- a/lib/post-json.js
+++ b/lib/post-json.js
@@ -3,6 +3,8 @@
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
 
+'use strict';
+
 var concat = require('concat-stream');
 var debug = require('debug')('strong-deploy');
 var getDeployEndpoint = require('./deploy-endpoint').get;

--- a/lib/put-file.js
+++ b/lib/put-file.js
@@ -3,6 +3,8 @@
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
 
+'use strict';
+
 var concat = require('concat-stream');
 var debug = require('debug')('strong-deploy');
 var fs = require('fs');

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -3,6 +3,8 @@
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
 
+'use strict';
+
 var assert = require('assert');
 var auth = require('http-auth');
 var cicada = require('strong-fork-cicada');

--- a/test/test-deploy-default-branch.js
+++ b/test/test-deploy-default-branch.js
@@ -3,6 +3,8 @@
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
 
+'use strict';
+
 var assert = require('assert');
 var childProcess = require('child_process');
 var concat = require('concat-stream');

--- a/test/test-deploy-from-workingdir.js
+++ b/test/test-deploy-from-workingdir.js
@@ -3,6 +3,8 @@
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
 
+'use strict';
+
 var assert = require('assert');
 var debug = require('debug')('test');
 var helpers = require('./helpers');

--- a/test/test-deploy-specific-branch.js
+++ b/test/test-deploy-specific-branch.js
@@ -3,6 +3,8 @@
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
 
+'use strict';
+
 var assert = require('assert');
 var childProcess = require('child_process');
 var shell = require('shelljs');

--- a/test/test-git-deploy-auth-failure.js
+++ b/test/test-git-deploy-auth-failure.js
@@ -3,6 +3,8 @@
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
 
+'use strict';
+
 var assert = require('assert');
 var childProcess = require('child_process');
 var debug = require('debug')('test');

--- a/test/test-git-deploy-auth.js
+++ b/test/test-git-deploy-auth.js
@@ -3,6 +3,8 @@
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
 
+'use strict';
+
 var assert = require('assert');
 var childProcess = require('child_process');
 var helpers = require('./helpers');

--- a/test/test-git-http-ssh.js
+++ b/test/test-git-http-ssh.js
@@ -3,6 +3,8 @@
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
 
+'use strict';
+
 var assert = require('assert');
 var childProcess = require('child_process');
 var helpers = require('./helpers');

--- a/test/test-put-deploy-auth-failure.js
+++ b/test/test-put-deploy-auth-failure.js
@@ -3,6 +3,8 @@
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
 
+'use strict';
+
 var assert = require('assert');
 var childProcess = require('child_process');
 var debug = require('debug')('test');

--- a/test/test-put-deploy-auth.js
+++ b/test/test-put-deploy-auth.js
@@ -3,6 +3,8 @@
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
 
+'use strict';
+
 var assert = require('assert');
 var childProcess = require('child_process');
 var helpers = require('./helpers');

--- a/test/test-put-file-deploy.js
+++ b/test/test-put-file-deploy.js
@@ -3,6 +3,8 @@
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
 
+'use strict';
+
 var assert = require('assert');
 var childProcess = require('child_process');
 var helpers = require('./helpers');

--- a/test/test-put-file-http-ssh.js
+++ b/test/test-put-file-http-ssh.js
@@ -3,6 +3,8 @@
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
 
+'use strict';
+
 var assert = require('assert');
 var childProcess = require('child_process');
 var helpers = require('./helpers');

--- a/test/test-usage.js
+++ b/test/test-usage.js
@@ -3,6 +3,8 @@
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
 
+'use strict';
+
 var assert = require('assert');
 var async = require('async');
 var debug = require('debug')('strong-deploy:test');


### PR DESCRIPTION
connected to https://github.com/strongloop-internal/scrum-nodeops/issues/1596

This is to prevent CI failures with eslint-config-strongloop@2.1.0
